### PR TITLE
chore: modernize devcontainer, CI toolchain, and coverage/dependency tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,12 @@
 {
     "name": "Rust",
-    "image": "mcr.microsoft.com/devcontainers/rust:bullseye",
+    "image": "ghcr.io/bare-devcontainer/rust:trixie",
+    "postCreateCommand": "rustup show",
     "customizations": {
         "vscode": {
             "extensions": [
                 "EditorConfig.EditorConfig"
-            ],
-            "settings": {
-                "rust-analyzer.checkOnSave.command": "clippy"
-            }
+            ]
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,36 @@
 {
     "name": "Rust",
     "image": "ghcr.io/bare-devcontainer/rust:trixie",
+    "remoteEnv": {
+        "EDITOR": "code --wait",
+        "VISUAL": "code --wait"
+    },
     "postCreateCommand": "rustup show",
+    "mounts": [
+        {
+            "source": "${devcontainerId}-rust-cargo-registry",
+            "target": "/home/dev/.cargo/registry",
+            "type": "volume"
+        },
+        {
+            "source": "${devcontainerId}-rust-cargo-git",
+            "target": "/home/dev/.cargo/git",
+            "type": "volume"
+        }
+    ],
     "customizations": {
         "vscode": {
             "extensions": [
-                "EditorConfig.EditorConfig"
-            ]
+                "anthropic.claude-code",
+                "EditorConfig.EditorConfig",
+                "rust-lang.rust-analyzer"
+            ],
+            "settings": {
+                "[rust]": {
+                    "editor.formatOnSave": true,
+                    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+                }
+            }
         }
     }
 }

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,7 +13,6 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - run: cargo install cargo-audit --locked
+      - run: cargo audit

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,22 +1,31 @@
+name: coverage
+
 on:
   push:
     branches:
       - main
   pull_request:
 
-name: coverage
+permissions: {}
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
+    environment: codecov
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-      - name: Push to coveralls.io
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+      - name: Generate coverage report
         run: |
-          cargo install cargo-tarpaulin
-          cargo tarpaulin --ciserver github-ci --coveralls $COVERALLS_REPO_TOKEN
+          cargo install cargo-tarpaulin --locked
+          cargo tarpaulin --ciserver github-ci --out Xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,21 +17,14 @@ jobs:
           - ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+      - name: Set up Rust
+        run: |
+          rustup update ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
+          rustup component add rustfmt clippy
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - run: cargo fmt --all -- --check
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -8,7 +8,7 @@ name: build
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         rust:
@@ -20,19 +20,13 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          components: rustfmt, clippy
+      - name: Set up Rust
+        run: |
+          rustup update ${{ matrix.rust }}
+          rustup default ${{ matrix.rust }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
+      - run: cargo build
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # usi-run
 
 [![Github Actions](https://github.com/nozaq/usi-run/workflows/build/badge.svg)](https://github.com/nozaq/usi-run/actions?workflow=build)
-[![Coverage Status](https://coveralls.io/repos/github/nozaq/usi-run/badge.svg)](https://coveralls.io/github/nozaq/usi-run)
 [![crates.io](https://img.shields.io/crates/v/usi-run.svg)](https://crates.io/crates/usi-run)
+[![codecov](https://codecov.io/gh/nozaq/usi-run/graph/badge.svg)](https://codecov.io/gh/nozaq/usi-run)
 
 A command line utility for automatically running games between USI compliant Shogi engines and collect match statistics.
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices",
+        ":semanticCommits",
+        ":semanticCommitTypeAll(chore)"
+    ],
+    "minimumReleaseAge": "14 days",
+    "labels": [
+        "deps"
+    ],
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "labels": [
+            "security"
+        ],
+        "minimumReleaseAge": null
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "stable"
-components = ["rustfmt", "clippy"]
+profile = "minimal"
+components = ["clippy", "rust-src", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
Mirrors the recent shogi-rs updates: switch to the bare-devcontainer
Rust image, pin the toolchain via rust-toolchain.toml, drop the
unmaintained actions-rs/* GitHub Actions in favor of plain
rustup/cargo steps (needed to keep CI working on current stable
Rust), migrate coverage reporting from Coveralls to Codecov, and
configure Renovate for dependency updates.